### PR TITLE
Added Swedish Dvorak (Svorak A1) layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Tested layouts:
 * Jawi Phonetic QWERTY
 * Romanian Programmers
 * Romanian Standard
+* Swedish Dvorak (Svorak A1)
 
 Experimental - not tested:
 * Canadian Multilingual Standard

--- a/app/src/main/res/raw/keyboard_layout_swedish_dvorak_a1.kcm
+++ b/app/src/main/res/raw/keyboard_layout_swedish_dvorak_a1.kcm
@@ -1,0 +1,388 @@
+# License: MIT
+
+# Swedish Dvorak (Svorak A1 by Liket)
+
+type OVERLAY
+
+map key 86 PLUS
+
+### ROW 1
+
+key GRAVE {
+    label:                              '\u00a7'
+    base:                               '\u00a7'
+    shift:                              '\u00bd'
+}
+
+key 1 {
+    label:                              '1'
+    base:                               '1'
+    shift:                              '!'
+}
+
+key 2 {
+    label:                              '2'
+    base:                               '2'
+    shift:                              '"'
+    ralt:                               '@'
+}
+
+key 3 {
+    label:                              '3'
+    base:                               '3'
+    shift:                              '#'
+    ralt:                               '\u00a3'
+}
+
+key 4 {
+    label:                              '4'
+    base:                               '4'
+    shift:                              '\u00a4'
+    ralt:                               '$'
+}
+
+key 5 {
+    label:                              '5'
+    base:                               '5'
+    shift:                              '%'
+    ralt:                               '\u20ac'
+}
+
+key 6 {
+    label:                              '6'
+    base:                               '6'
+    shift:                              '&'
+}
+
+key 7 {
+    label:                              '7'
+    base:                               '7'
+    shift:                              '/'
+    ralt:                               '{'
+}
+
+key 8 {
+    label:                              '8'
+    base:                               '8'
+    shift:                              '('
+    ralt:                               '['
+}
+
+key 9 {
+    label:                              '9'
+    base:                               '9'
+    shift:                              ')'
+    ralt:                               ']'
+}
+
+key 0 {
+    label:                              '0'
+    base:                               '0'
+    shift:                              '='
+    ralt:                               '}'
+}
+
+key MINUS {
+    label:                              '+'
+    base:                               '+'
+    shift:                              '?'
+    ralt:                               '\\'
+}
+
+key EQUALS {
+    label:                              '\u00b4'
+    base:                               '\u0301'
+    shift:                              '\u0300'
+}
+
+### ROW 2
+
+# Å
+key Q {
+    label:                              '\u00c5'
+    base:                               '\u00e5'
+    shift, capslock:                    '\u00c5'
+}
+
+# Ä
+key W {
+    label:                              '\u00c4'
+    base:                               '\u00e4'
+    shift, capslock:                    '\u00c4'
+    ralt:                               '\u00e6'
+    ralt+capslock, shift+ralt:          '\u00c6'
+}
+
+# Ö
+key E {
+    label:                              '\u00d6'
+    base:                               '\u00f6'
+    shift, capslock:                    '\u00d6'
+    ralt:                               '\u00f8'
+    ralt+capslock, shift+ralt:          '\u00d8'
+}
+
+# P
+key R {
+    label:                              'P'
+    base:                               'p'
+    shift, capslock:                    'P'
+}
+
+# Y
+key T {
+    label:                              'Y'
+    base:                               'y'
+    shift, capslock:                    'Y'
+}
+
+# F
+key Y {
+    label:                              'F'
+    base:                               'f'
+    shift, capslock:                    'F'
+    ralt:                               '\u01e5'
+    ralt+capslock, shift+ralt:          '\u01e4'
+}
+
+# G
+key U {
+    label:                              'G'
+    base:                               'g'
+    shift, capslock:                    'G'
+    ralt:                               '\u01e7'
+    ralt+capslock, shift+ralt:          '\u01e6'
+}
+
+# C
+key I {
+    label:                              'C'
+    base:                               'c'
+    shift, capslock:                    'C'
+    ralt:                               '\u010d'
+    ralt+capslock, shift+ralt:          '\u010c'
+}
+
+# R
+key O {
+    label:                              'R'
+    base:                               'r'
+    shift, capslock:                    'R'
+}
+
+# L
+key P {
+    label:                              'L'
+    base:                               'l'
+    shift, capslock:                    'L'
+}
+
+# ,
+key LEFT_BRACKET {
+    label:                              ','
+    base:                               ','
+    shift:                              ';'
+}
+
+# ¨
+key RIGHT_BRACKET {
+    label:                              '\u00a8'
+    base:                               '\u0308'
+    shift:                              '\u0302'
+    ralt:                               '\u0303'
+}
+
+### ROW 3
+
+# A
+key A {
+    label:                              'A'
+    base:                               'a'
+    shift, capslock:                    'A'
+    ralt:                               '\u00e1'
+    ralt+capslock, shift+ralt:          '\u00c1'
+}
+
+# O
+key S {
+    label:                              'O'
+    base:                               'o'
+    shift, capslock:                    'O'
+    ralt:                               '\u00f5'
+    ralt+capslock, shift+ralt:          '\u00d5'
+}
+
+# E
+key D {
+    label:                              'E'
+    base:                               'e'
+    shift, capslock:                    'E'
+    ralt:                               '\u20ac'
+    ralt+capslock:                      '\u20ac'
+}
+
+# U
+key F {
+    label:                              'U'
+    base:                               'u'
+    shift, capslock:                    'U'
+}
+
+# I
+key G {
+    label:                              'I'
+    base:                               'i'
+    shift, capslock:                    'I'
+    ralt:                               '\u00ef'
+    ralt+capslock, shift+ralt:          '\u00cf'
+}
+
+# D
+key H {
+    label:                              'D'
+    base:                               'd'
+    shift, capslock:                    'D'
+    ralt:                               '\u0111'
+    ralt+capslock, shift+ralt:          '\u0110'
+}
+
+# H
+key J {
+    label:                              'H'
+    base:                               'h'
+    shift, capslock:                    'H'
+    ralt:                               '\u021f'
+    ralt+capslock, shift+ralt:          '\u021e'
+}
+
+# T
+key K {
+    label:                              'T'
+    base:                               't'
+    shift, capslock:                    'T'
+    ralt:                               '\u0167'
+    ralt+capslock, shift+ralt:          '\u0166'
+}
+
+# N
+key L {
+    label:                              'N'
+    base:                               'n'
+    shift, capslock:                    'N'
+    ralt:                               '\u014b'
+    ralt+capslock, shift+ralt:          '\u014a'
+}
+
+# S
+key SEMICOLON {
+    label:                              'S'
+    base:                               's'
+    shift, capslock:                    'S'
+    ralt:                               '\u0161'
+    ralt+capslock, shift+ralt:          '\u0160'
+}
+
+# -
+key APOSTROPHE {
+    label:                              '-'
+    base:                               '-'
+    shift:                              '_'
+}
+
+# '
+key BACKSLASH {
+    label:                              '\''
+    base:                               '\''
+    shift:                              '*'
+}
+
+### ROW 4
+
+# <
+key PLUS {
+    label:                              '<'
+    base:                               '<'
+    shift:                              '>'
+    ralt:                               '|'
+}
+
+# .
+key Z {
+    label:                              '.'
+    base:                               '.'
+    shift:                              ':'
+}
+
+# Q
+key X {
+    label:                              'Q'
+    base:                               'q'
+    shift, capslock:                    'Q'
+    ralt:                               '\u00e2'
+    ralt+capslock, shift+ralt:          '\u00c2'
+}
+
+# J
+key C {
+    label:                              'J'
+    base:                               'j'
+    shift, capslock:                    'J'
+}
+
+# K
+key V {
+    label:                              'K'
+    base:                               'k'
+    shift, capslock:                    'K'
+    ralt:                               '\u01e9'
+    ralt+capslock, shift+ralt:          '\u01e8'
+}
+
+# X
+key B {
+    label:                              'X'
+    base:                               'x'
+    shift, capslock:                    'X'
+}
+
+# B
+key N {
+    label:                              'B'
+    base:                               'b'
+    shift, capslock:                    'B'
+    ralt:                               '\u0292'
+    ralt+capslock, shift+ralt:          '\u01b7'
+}
+
+# M
+key M {
+    label:                              'M'
+    base:                               'm'
+    shift, capslock:                    'M'
+    ralt, ralt+capslock:                '\u00b5'
+}
+
+# W
+key COMMA {
+    label:                              'W'
+    base:                               'w'
+    shift, capslock:                    'W'
+}
+
+# V
+key PERIOD {
+    label:                              'V'
+    base:                               'v'
+    shift, capslock:                    'V'
+    ralt:                               '\u01ef'
+    ralt+capslock, shift+ralt:          '\u01ee'
+}
+
+# Z
+key SLASH {
+    label:                              'Z'
+    base:                               'z'
+    shift, capslock:                    'Z'
+    ralt:                               '\u017e'
+    ralt+capslock, shift+ralt:          '\u017d'
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -120,6 +120,7 @@
 	<string name="keyboard_layout_belgian_period">Belgian (Period)</string>
 	<string name="keyboard_layout_serbian_latin">Serbian (Latin)</string>
 	<string name="keyboard_layout_azeri_cyrillic">Azeri Cyrillic</string>
+	<string name="keyboard_layout_swedish_dvorak_a1">Swedish Dvorak (Svorak A1)</string>
 	<string name="keyboard_layout_swedish_with_sami">Swedish with Sami</string>
 	<string name="keyboard_layout_uzbek_cyrillic">Uzbek Cyrillic</string>
 	<string name="keyboard_layout_mongolian_mongolian_script">Mongolian (Mongolian Script)</string>

--- a/app/src/main/res/xml/keyboard_layouts.xml
+++ b/app/src/main/res/xml/keyboard_layouts.xml
@@ -118,6 +118,7 @@
     <keyboard-layout android:label="@string/keyboard_layout_belgian_period" android:name="keyboard_layout_belgian_period" android:keyboardLayout="@raw/keyboard_layout_belgian_period"/>
     <keyboard-layout android:label="@string/keyboard_layout_serbian_latin" android:name="keyboard_layout_serbian_latin" android:keyboardLayout="@raw/keyboard_layout_serbian_latin"/>
     <keyboard-layout android:label="@string/keyboard_layout_azeri_cyrillic" android:name="keyboard_layout_azeri_cyrillic" android:keyboardLayout="@raw/keyboard_layout_azeri_cyrillic"/>
+    <keyboard-layout android:label="@string/keyboard_layout_swedish_dvorak_a1" android:name="keyboard_layout_swedish_dvorak_a1" android:keyboardLayout="@raw/keyboard_layout_swedish_dvorak_a1"/>
     <keyboard-layout android:label="@string/keyboard_layout_swedish_with_sami" android:name="keyboard_layout_swedish_with_sami" android:keyboardLayout="@raw/keyboard_layout_swedish_with_sami"/>
     <keyboard-layout android:label="@string/keyboard_layout_uzbek_cyrillic" android:name="keyboard_layout_uzbek_cyrillic" android:keyboardLayout="@raw/keyboard_layout_uzbek_cyrillic"/>
     <keyboard-layout android:label="@string/keyboard_layout_mongolian_mongolian_script" android:name="keyboard_layout_mongolian_mongolian_script" android:keyboardLayout="@raw/keyboard_layout_mongolian_mongolian_script"/>


### PR DESCRIPTION
This is the A1 style dvorak layout described here:
http://aoeu.info/s/dvorak/svorak

It is based on the default swedish QWERTY layout in android (i.e.
keyboard_layout_swedish.kcm) but has ALPHA keys reordered according to
the Svorak A1 layout.